### PR TITLE
fix: add tcp_keep_alive_count support for listen fields

### DIFF
--- a/common/listener/listener_tcp.go
+++ b/common/listener/listener_tcp.go
@@ -43,10 +43,15 @@ func (l *Listener) ListenTCP() (net.Listener, error) {
 		if keepInterval == 0 {
 			keepInterval = C.TCPKeepAliveInterval
 		}
+		keepCount := l.listenOptions.TCPKeepAliveCount
+		if keepCount < 0 {
+			keepCount = 0
+		}
 		listenConfig.KeepAliveConfig = net.KeepAliveConfig{
 			Enable:   true,
 			Idle:     keepIdle,
 			Interval: keepInterval,
+			Count:    keepCount,
 		}
 	}
 	if l.listenOptions.TCPMultiPath {

--- a/option/inbound.go
+++ b/option/inbound.go
@@ -68,6 +68,7 @@ type ListenOptions struct {
 	DisableTCPKeepAlive         bool               `json:"disable_tcp_keep_alive,omitempty"`
 	TCPKeepAlive                badoption.Duration `json:"tcp_keep_alive,omitempty"`
 	TCPKeepAliveInterval        badoption.Duration `json:"tcp_keep_alive_interval,omitempty"`
+	TCPKeepAliveCount           int                `json:"tcp_keep_alive_count,omitempty"`
 	TCPFastOpen                 bool               `json:"tcp_fast_open,omitempty"`
 	TCPMultiPath                bool               `json:"tcp_multi_path,omitempty"`
 	UDPFragment                 *bool              `json:"udp_fragment,omitempty"`

--- a/option/outbound.go
+++ b/option/outbound.go
@@ -80,6 +80,7 @@ type DialerOptions struct {
 	DisableTCPKeepAlive  bool                              `json:"disable_tcp_keep_alive,omitempty"`
 	TCPKeepAlive         badoption.Duration                `json:"tcp_keep_alive,omitempty"`
 	TCPKeepAliveInterval badoption.Duration                `json:"tcp_keep_alive_interval,omitempty"`
+	TCPKeepAliveCount    int                               `json:"tcp_keep_alive_count,omitempty"`
 	UDPFragment          *bool                             `json:"udp_fragment,omitempty"`
 	UDPFragmentDefault   bool                              `json:"-"`
 	DomainResolver       *DomainResolveOptions             `json:"domain_resolver,omitempty"`
@@ -87,8 +88,6 @@ type DialerOptions struct {
 	NetworkType          badoption.Listable[InterfaceType] `json:"network_type,omitempty"`
 	FallbackNetworkType  badoption.Listable[InterfaceType] `json:"fallback_network_type,omitempty"`
 	FallbackDelay        badoption.Duration                `json:"fallback_delay,omitempty"`
-
-	TCPKeepAliveCount int `json:"tcp_keep_alive_count,omitempty"`
 
 	// Deprecated: migrated to domain resolver
 	DomainStrategy DomainStrategy `json:"domain_strategy,omitempty"`


### PR DESCRIPTION
Follow-up to commit 7d31b40 which added tcp_keep_alive_count for dial fields only.

Add TCPKeepAliveCount to ListenOptions (inbound) and apply it in
listener_tcp.go, complementing the existing outbound-only support.

The current listener_tcp.go already uses net.KeepAliveConfig but is
missing the Count field, so tcp_keep_alive_count only works on outbound.

Changes:
- option/inbound.go: add TCPKeepAliveCount to ListenOptions
- common/listener/listener_tcp.go: read and apply Count to KeepAliveConfig
- option/outbound.go: move TCPKeepAliveCount next to TCPKeepAliveInterval for consistency