### PR TITLE
fix(provider): fix early data extraction in websocket path

### DIFF
--- a/provider/parser/link.go
+++ b/provider/parser/link.go
@@ -112,13 +112,17 @@ func shadowsocksPluginOptions(plugin string) string {
 }
 
 func v2rayTransportWsPath(WebsocketOptions *option.V2RayWebsocketOptions, path string) {
-	reg := regexp.MustCompile(`^(.*?)(?:\?ed=(\d*))?$`)
-	result := reg.FindStringSubmatch(path)
-	WebsocketOptions.Path = result[1]
-	if result[2] != "" {
+	if m := regexp.MustCompile(`[?&]ed=(\d+)`).FindStringSubmatch(path); len(m) > 1 {
 		WebsocketOptions.EarlyDataHeaderName = "Sec-WebSocket-Protocol"
-		WebsocketOptions.MaxEarlyData = StringToType[uint32](result[2])
+		WebsocketOptions.MaxEarlyData = StringToType[uint32](m[1])
+		path = regexp.MustCompile(`(\?ed=\d+&)|(&ed=\d+)|(\?ed=\d+)`).ReplaceAllStringFunc(path, func(match string) string {
+			if strings.HasPrefix(match, "?") && strings.HasSuffix(match, "&") {
+				return "?"
+			}
+			return ""
+		})
 	}
+	WebsocketOptions.Path = path
 }
 
 func v2rayTransportWs(host string, path string) option.V2RayWebsocketOptions {

--- a/provider/parser/link_test.go
+++ b/provider/parser/link_test.go
@@ -142,3 +142,16 @@ func TestParseHysteria2LinkOptions(t *testing.T) {
 	require.Equal(t, "example.com", options.TLS.ServerName)
 	require.Equal(t, "AA:BB", options.TLS.CertificatePinSHA256)
 }
+
+func TestParseVLESSLinkWSEarlyData(t *testing.T) {
+	link := "vless://11111111-1111-1111-1111-111111111111@example.com:443?type=ws&security=tls&host=example.com&path=%2F%3Fproxyip%3Dproxyip.example.com%26ed%3D2560#test"
+	outbound, err := ParseSubscriptionLink(link)
+	require.NoError(t, err)
+
+	options := outbound.Options.(*option.VLESSOutboundOptions)
+	require.NotNil(t, options.Transport)
+	require.Equal(t, "ws", options.Transport.Type)
+	require.Equal(t, "/?proxyip=proxyip.example.com", options.Transport.WebsocketOptions.Path)
+	require.Equal(t, uint32(2560), options.Transport.WebsocketOptions.MaxEarlyData)
+	require.Equal(t, "Sec-WebSocket-Protocol", options.Transport.WebsocketOptions.EarlyDataHeaderName)
+}


### PR DESCRIPTION
Fix early data (ed) extraction in websocket path so it can be extracted regardless of query parameter ordering, and strip ed from the path properly.